### PR TITLE
バトルステータスを構造体としてメンバに持つよう変更

### DIFF
--- a/CUI-RPG/BattleCharacter.hpp
+++ b/CUI-RPG/BattleCharacter.hpp
@@ -11,43 +11,66 @@ public:
     using string = std::string;
     using ability_t = signed short;
 
+protected:
+    struct Status
+    {
+        Status(ability_t hp, ability_t mp, ability_t attack, ability_t defense, ability_t speed)
+            : hp(hp), mp(mp), attack(attack), defense(defense), speed(speed) {}
+        ~Status() {}
+
+        ability_t hp;
+        ability_t mp;
+        ability_t attack;
+        ability_t defense;
+        ability_t speed;
+    };
+
+public:
     BattleCharacter(string name, ability_t hp, ability_t mp, ability_t attack, ability_t defense, ability_t speed)
-        : m_name(name), m_hp(hp), m_mp(mp), m_attack(attack), m_defense(defense), m_speed(speed), m_state(State::NORMAL) {}
+        : m_name(name), m_state(State::NORMAL), m_initStatus(hp, mp, attack, defense, speed), m_battleStatus(hp, mp, attack, defense, speed) {}
 
     virtual ~BattleCharacter() {}
 
-public:
     void Attack(BattleCharacter& receiver)
     {
-        ability_t damage = m_attack - (receiver.GetDefense() / 2);
-        receiver.SetHp(receiver.GetHp() - damage);
+        ability_t damage = GetBattleAttack() - (receiver.GetBattleDefense() / 2);
+        receiver.SetBattleHp(receiver.GetBattleHp() - damage);
         std::cout << receiver.GetName() << " に" << damage << "ダメージ" << std::endl;
     }
 
-    bool IsFaster(const BattleCharacter& another) const
+    void Defense()
     {
-        return m_speed >= another.GetSpeed();
+
     }
 
-    bool IsDie() { return m_hp == 0; }
+    bool IsFaster(const BattleCharacter& other) const
+    {
+        return GetBattleSpeed() >= other.GetBattleSpeed();
+    }
+
+    bool IsDie() { return GetBattleHp() == 0; }
 
     string GetName() const { return m_name; }
-    ability_t GetHp() const { return m_hp; }
-    ability_t GetDefense() const { return m_defense; }
-    ability_t GetSpeed() const { return m_speed; }
     State& GetState() { return m_state; }
 
-    void SetHp(ability_t hp) { m_hp = (hp < 0) ? 0 : hp; }
+    const ability_t GetBattleHp() const { return m_battleStatus.hp; }
+    const ability_t GetBattleAttack() const { return m_battleStatus.attack; }
+    const ability_t GetBattleDefense() const { return m_battleStatus.defense; }
+    const ability_t GetBattleSpeed() const { return m_battleStatus.speed; }
+
+    Status& GetInitStatus() { return m_initStatus; }
+    Status& GetBattleStatus() { return m_battleStatus; }
+    const Status& GetInitStatus() const { return m_initStatus; }
+    const Status& GetBattleStatus() const { return m_battleStatus; }
+
+    void SetBattleHp(ability_t hp) { m_battleStatus.hp = (hp < 0) ? 0 : hp; }
     void SetState(State state) { m_state = state; }
 
 protected:
     string m_name;
-    ability_t m_hp;
-    ability_t m_mp;
-    ability_t m_attack;
-    ability_t m_defense;
-    ability_t m_speed;
     State m_state;
+    Status m_initStatus;
+    Status m_battleStatus;
 };
 
 #endif // !BATTLE_CHARACTER_H_


### PR DESCRIPTION
それと、フィールドとしてアクセスするのではなくgetterからアクセスするように統一
修正前: receiver.m_battlestatus.defense　や　m_battleStatus.speed
修正後: receiver.GetBattleDefense()　や　GetBattleSpeed()