### PR TITLE
エラー内容が変わった

### DIFF
--- a/CUI-RPG/BattleCharacter.hpp
+++ b/CUI-RPG/BattleCharacter.hpp
@@ -47,7 +47,7 @@ public:
         return receiver.IsDefense() ? damage / 2 : damage;
     }
 
-    void Turn(BattleCharacter other)
+    void Turn(BattleCharacter& other)
     {
         UnDefense();
 

--- a/CUI-RPG/StateOperation.hpp
+++ b/CUI-RPG/StateOperation.hpp
@@ -1,8 +1,9 @@
 #ifndef STATE_H_
 #define STATE_H_
 
-#include "BattleCharacter.hpp"
 #include "State.hpp"
+
+class BattleCharacter;
 
 class StateOperation
 {


### PR DESCRIPTION
もしかしたらStateOperation.hppとBattleCharacter.hppが相互にインクルードしあっているのが原因なのではと思い、
「C++ 相互インクルード」で検索をかけて出てきた以下のサイトを見てみた。

https://qiita.com/screwyscrew/items/c947fe190d606be4c95b
https://shignpost.blogspot.com/2012/01/blog-post_08.html
https://arvitos.hatenadiary.org/entry/20090213/1234519302 
(↑のページは検索で出てきたのではなく、1つ上のページ内にリンクが記載されていたもの このページが一番わかりやすい)

前方宣言すれば解決するとのことだったため、
StateOperation.hppの方でBattleCharacterを前方宣言してビルドしてみると、
エラーの内容が変わり以下のエラーになった。

C2027 認識できない型 'BattleCharacter' が使われています。 StateOperation.hpp 13, 18, 23, 28, 33

C2027のMS公式サイトである以下を見てみる。
https://learn.microsoft.com/ja-jp/cpp/error-messages/compiler-errors-1/compiler-error-c2027?view=msvc-170

「宣言されているが未定義の型へのポインターを宣言することができます。 
ただし、C++ では未定義の型への参照は許可されません。」
と記述してあることから、引数に指定している BattleCharacter& の記述でまずエラーが起きていたのだと思い(実際は違う)、
引数を BattleCharacter* のようにポインタ型にしてみると、
次はその関数内に記述している target.SetState(), target.GetState() のところで
「式にはクラス型を使用する必要がありますが、型 "BattleCharacter" が使用されています」とのエラーが表示される。

色々調べたりここまでやってみて、ようやくぼんやりとわかってきた。
相互にインクルードした場合、片方は定義が見えないのでそこでエラーが起きる。
前方宣言だけでは定義がわからないため、当然メンバ関数にアクセスできないのでエラーが起きる。
というか、BattleCharacter& のところも&を使って参照にしているのがエラーの原因なのではなく、
ポインタの時と同じで定義が見えないからメンバ関数にアクセスできないのがエラーの原因である。

解決策としては、ヘッダとソースにファイルを分離した上でお互いのヘッダで前方宣言を記述し、
ソースで2つのヘッダをインクルードすれば、どちらの定義も見えて解決できるとのこと。
一番わかりやすいサイトにそう記載されていたため、試してみる。