### PR TITLE
brave, enemyをBattleCharacterへのポインタ型として生成するように修正

### DIFF
--- a/CUI-RPG/BattleCharacter.cpp
+++ b/CUI-RPG/BattleCharacter.cpp
@@ -1,22 +1,23 @@
 #include "BattleCharacter.hpp"
 #include "StateOperation.hpp"
 
-bool BattleCharacter::Turn(BattleCharacter& other)
+bool BattleCharacter::Turn(BattleCharacter* other)
 {
     UnDefense();
 
-    if (StateOperation::IsState(*this, State::PARALYSIS)
-        || StateOperation::IsState(*this, State::SLEEP)) {
+    if (StateOperation::IsState(this, State::PARALYSIS)
+        || StateOperation::IsState(this, State::SLEEP)) {
         std::cout << "行動不能" << std::endl;
     } else {
         Action(other);
     }
 
-    if (StateOperation::IsState(*this, State::POISON)) {
+    if (StateOperation::IsState(this, State::POISON)) {
         PoisonDamage();
     }
 
     if (IsDie()) {
+        DiePrint();
         return false;
     }
 

--- a/CUI-RPG/BattleCharacter.hpp
+++ b/CUI-RPG/BattleCharacter.hpp
@@ -35,23 +35,23 @@ public:
 
     virtual ~BattleCharacter() {}
 
-    void Attack(BattleCharacter& receiver)
+    void Attack(BattleCharacter* receiver)
     {
         ability_t damage = CalcAttackDamage(receiver);
-        receiver.SetBattleHp(receiver.GetBattleHp() - damage);
-        std::cout << receiver.GetName() << " に" << damage << "ダメージ" << std::endl;
+        receiver->SetBattleHp(receiver->GetBattleHp() - damage);
+        std::cout << receiver->GetName() << " に" << damage << "ダメージ" << std::endl;
     }
 
-    int CalcAttackDamage(BattleCharacter& receiver)
+    int CalcAttackDamage(BattleCharacter* receiver)
     {
-        ability_t damage = GetBattleAttack() - (receiver.GetBattleDefense() / 2);
-        return receiver.IsDefense() ? damage / 2 : damage;
+        ability_t damage = GetBattleAttack() - (receiver->GetBattleDefense() / 2);
+        return receiver->IsDefense() ? damage / 2 : damage;
     }
 
-    bool Turn(BattleCharacter& other);
+    bool Turn(BattleCharacter* other);
 
-    // Brave,Enemyでそれぞれ実装しなければならない
-    virtual void Action(BattleCharacter other) {}
+    virtual void Action(BattleCharacter* other) = 0;
+    virtual void DiePrint() = 0;
 
     void PoisonDamage()
     {
@@ -61,13 +61,11 @@ public:
 
     void Defense() { m_isDefense = true; }
 
-    void UnDefense() { m_isDefense = false; }
+    bool IsDefense() const { return m_isDefense; }
 
-    bool IsDefense() { return m_isDefense; }
-
-    bool IsFaster(const BattleCharacter& other) const
+    bool IsFaster(const BattleCharacter* other) const
     {
-        return GetBattleSpeed() >= other.GetBattleSpeed();
+        return GetBattleSpeed() >= other->GetBattleSpeed();
     }
 
     bool IsDie() { return GetBattleHp() == 0; }
@@ -94,6 +92,9 @@ public:
     void SetBattleHp(ability_t hp) { m_battleStatus.hp = (hp < 0) ? 0 : hp; }
     void SetBattleDefense(ability_t defense) { m_battleStatus.defense = defense; }
     void SetState(State state) { m_state = state; }
+
+private:
+    void UnDefense() { m_isDefense = false; }
 
 protected:
     string m_name;

--- a/CUI-RPG/Brave.hpp
+++ b/CUI-RPG/Brave.hpp
@@ -2,6 +2,7 @@
 #define BRAVE_H_
 
 #include "BattleCharacter.hpp"
+#include <iostream>
 
 class Brave : public BattleCharacter
 {
@@ -10,9 +11,14 @@ public:
         : BattleCharacter(name, hp, mp, attack, defense, speed) {}
     ~Brave() {}
 
-    void Action(BattleCharacter enemy)
+    void Action(BattleCharacter* enemy)
     {
         Attack(enemy);
+    }
+
+    void DiePrint()
+    {
+        std::cout << "ゆうしゃはしんでしまった！" << std::endl;
     }
 };
 

--- a/CUI-RPG/Enemy.hpp
+++ b/CUI-RPG/Enemy.hpp
@@ -2,6 +2,7 @@
 #define ENEMY_H_
 
 #include "BattleCharacter.hpp"
+#include <iostream>
 
 class Enemy : public BattleCharacter
 {
@@ -10,9 +11,14 @@ public:
         : BattleCharacter(name, hp, mp, attack, defense, speed) {}
     ~Enemy() {}
 
-    void Action(BattleCharacter brave)
+    void Action(BattleCharacter* brave)
     {
         Attack(brave);
+    }
+
+    void DiePrint()
+    {
+        std::cout << m_name << "をたおした！" << std::endl;
     }
 };
 

--- a/CUI-RPG/StateOperation.cpp
+++ b/CUI-RPG/StateOperation.cpp
@@ -1,27 +1,27 @@
 #include "StateOperation.hpp"
 #include "BattleCharacter.hpp"
 
-void StateOperation::SetState(BattleCharacter& target, State abnormal)
+void StateOperation::SetState(BattleCharacter* target, State abnormal)
 {
-    target.SetState((target.GetState() | abnormal));
+    target->SetState((target->GetState() | abnormal));
 }
 
-void StateOperation::RemoveState(BattleCharacter& target, State abnormal)
+void StateOperation::RemoveState(BattleCharacter* target, State abnormal)
 {
-    target.SetState((target.GetState() & ~abnormal));
+    target->SetState((target->GetState() & ~abnormal));
 }
 
-void StateOperation::SetNormal(BattleCharacter& target)
+void StateOperation::SetNormal(BattleCharacter* target)
 {
-    target.SetState(State::NORMAL);
+    target->SetState(State::NORMAL);
 }
 
-bool StateOperation::IsState(const BattleCharacter& target, State abnormal)
+bool StateOperation::IsState(const BattleCharacter* target, State abnormal)
 {
-    return (target.GetState() & abnormal) == abnormal;
+    return (target->GetState() & abnormal) == abnormal;
 }
 
-bool StateOperation::IsNormal(const BattleCharacter& target)
+bool StateOperation::IsNormal(const BattleCharacter* target)
 {
-    return target.GetState() == State::NORMAL;
+    return target->GetState() == State::NORMAL;
 }

--- a/CUI-RPG/StateOperation.hpp
+++ b/CUI-RPG/StateOperation.hpp
@@ -8,15 +8,15 @@ class BattleCharacter;
 class StateOperation
 {
 public:
-    static void SetState(BattleCharacter& target, State abnormal);
+    static void SetState(BattleCharacter* target, State abnormal);
 
-    static void RemoveState(BattleCharacter& target, State abnormal);
+    static void RemoveState(BattleCharacter* target, State abnormal);
 
-    static void SetNormal(BattleCharacter& target);
+    static void SetNormal(BattleCharacter* target);
 
-    static bool IsState(const BattleCharacter& target, State abnormal);
+    static bool IsState(const BattleCharacter* target, State abnormal);
 
-    static bool IsNormal(const BattleCharacter& target);
+    static bool IsNormal(const BattleCharacter* target);
 };
 
 #endif // !STATE_H_

--- a/CUI-RPG/main.cpp
+++ b/CUI-RPG/main.cpp
@@ -8,25 +8,42 @@
 #include <vector>
 using namespace std;
 
+class A
+{
+public:
+    virtual void a() { cout << "A" << endl; }
+};
+
+class B : public A
+{
+    void a() { cout << "B" << endl; }
+};
+
 int main()
 {
-    BattleCharacter brave("kamei", 10, 5, 5, 5, 5);
-    BattleCharacter enemy("enemy", 7, 4, 3, 3, 8);
+    A* b = new B();
+    b->a();
+
+    A* a = new A();
+    a->a();
+
+    BattleCharacter* brave = new Brave("kamei", 10, 5, 5, 5, 5);
+    BattleCharacter* enemy = new Enemy("enemy", 7, 4, 3, 3, 8);
     StateOperation::SetState(brave, State::POISON);
 
-    while (!brave.IsDie() && !enemy.IsDie()) {
-        if (brave.IsFaster(enemy)) {
-            if (!brave.Turn(enemy)) {
+    while (!brave->IsDie() && !enemy->IsDie()) {
+        if (brave->IsFaster(enemy)) {
+            if (!brave->Turn(enemy)) {
                 break;
             }
-            if (!enemy.Turn(brave)) {
+            if (!enemy->Turn(brave)) {
                 break;
             }
         } else {
-            if (!enemy.Turn(brave)) {
+            if (!enemy->Turn(brave)) {
                 break;
             }
-            if (!brave.Turn(enemy)) {
+            if (!brave->Turn(enemy)) {
                 break;
             }
         }


### PR DESCRIPTION
以前の実装ではbrave,enemyがBattleCharacter型のオブジェクトとして生成されてしまっていたため、
Action()やDiePrint()がBrave, Enemyでそれぞれ定義したものではなく、BattleCharacterで定義した空実装が使われてしまう。
そのため、BattleCharacterへのポインタ型として、それぞれのクラスをnewする形に修正。