### PR TITLE
IsDie()を修正

### DIFF
--- a/CUI-RPG/BattleCharacter.cpp
+++ b/CUI-RPG/BattleCharacter.cpp
@@ -17,7 +17,6 @@ bool BattleCharacter::Turn(BattleCharacter* other)
     }
 
     if (IsDie()) {
-        DiePrint();
         return false;
     }
 

--- a/CUI-RPG/BattleCharacter.hpp
+++ b/CUI-RPG/BattleCharacter.hpp
@@ -51,7 +51,6 @@ public:
     bool Turn(BattleCharacter* other);
 
     virtual void Action(BattleCharacter* other) = 0;
-    virtual void DiePrint() = 0;
 
     void PoisonDamage()
     {
@@ -68,7 +67,17 @@ public:
         return GetBattleSpeed() >= other->GetBattleSpeed();
     }
 
-    bool IsDie() { return GetBattleHp() == 0; }
+    bool IsDie()
+    {
+        if (GetBattleHp() == 0) {
+            DiePrint();
+            return true;
+        }
+        
+        return false;
+    }
+
+    virtual void DiePrint() = 0;
 
     string GetName() const { return m_name; }
     State& GetState() { return m_state; }

--- a/CUI-RPG/main.cpp
+++ b/CUI-RPG/main.cpp
@@ -8,28 +8,11 @@
 #include <vector>
 using namespace std;
 
-class A
-{
-public:
-    virtual void a() { cout << "A" << endl; }
-};
-
-class B : public A
-{
-    void a() { cout << "B" << endl; }
-};
-
 int main()
 {
-    A* b = new B();
-    b->a();
-
-    A* a = new A();
-    a->a();
-
     BattleCharacter* brave = new Brave("kamei", 10, 5, 5, 5, 5);
     BattleCharacter* enemy = new Enemy("enemy", 7, 4, 3, 3, 8);
-    StateOperation::SetState(brave, State::POISON);
+    //StateOperation::SetState(brave, State::POISON);
 
     while (!brave->IsDie() && !enemy->IsDie()) {
         if (brave->IsFaster(enemy)) {


### PR DESCRIPTION
Turn()内でDiePrint()を使う実装だと、バトルループのwhile文判定でHPが0だとわかった時に、
DiePrint()が呼び出されないため、IsDie()内でif判定をする形に修正。