### PR TITLE
レベルアップ処理、Battleクラスの実装と色々修正など

### DIFF
--- a/CUI-RPG/Battle.hpp
+++ b/CUI-RPG/Battle.hpp
@@ -1,0 +1,50 @@
+#ifndef BATTLE_H_
+#define BATTLE_H_
+
+#include "BattleCharacter.hpp"
+#include "Brave.hpp"
+
+class Battle
+{
+public:
+    static void BattleEvent(Brave* brave, Enemy* enemy)
+    {
+        BattleLoop(brave, enemy);
+        AfterBattle(brave, enemy);
+    }
+
+    static void BattleLoop(Brave* brave, Enemy* enemy)
+    {
+        enemy->Encount();
+
+        while (!brave->IsDie() && !enemy->IsDie()) {
+            if (brave->IsFaster(enemy)) {
+                if (!brave->Turn(enemy)) {
+                    break;
+                }
+                if (!enemy->Turn(brave)) {
+                    break;
+                }
+            } else {
+                if (!enemy->Turn(brave)) {
+                    break;
+                }
+                if (!brave->Turn(enemy)) {
+                    break;
+                }
+            }
+        }
+    }
+
+    static void AfterBattle(Brave* brave, Enemy* enemy)
+    {
+        if (brave->IsDie()) {
+            brave->GameOver();
+        } else {
+            enemy->DiePrint();
+            brave->OnLevelUp(enemy->GetExp());
+        }
+    }
+};
+
+#endif // !BATTLE_H_

--- a/CUI-RPG/BattleCharacter.cpp
+++ b/CUI-RPG/BattleCharacter.cpp
@@ -3,11 +3,14 @@
 
 bool BattleCharacter::Turn(BattleCharacter* other)
 {
+    if (IsDie()) { return false; }
+
     UnDefense();
 
+    // TODO: 状態異常の名前も表示するように実装する
     if (StateOperation::IsState(this, State::PARALYSIS)
         || StateOperation::IsState(this, State::SLEEP)) {
-        std::cout << "行動不能" << std::endl;
+        std::cout << "こうどうふのう" << std::endl;
     } else {
         Action(other);
     }
@@ -16,9 +19,5 @@ bool BattleCharacter::Turn(BattleCharacter* other)
         PoisonDamage();
     }
 
-    if (IsDie()) {
-        return false;
-    }
-
-    return true;
+    return !IsDie();
 }

--- a/CUI-RPG/BattleCharacter.hpp
+++ b/CUI-RPG/BattleCharacter.hpp
@@ -40,7 +40,7 @@ public:
         std::cout << m_name << "のこうげき！" << std::endl;
         ability_t damage = CalcAttackDamage(receiver);
         receiver->SetBattleHp(receiver->GetBattleHp() - damage);
-        std::cout << receiver->GetName() << " に" << damage << "ダメージ" << std::endl;
+        std::cout << receiver->GetName() << "に " << damage << " ダメージ" << std::endl;
     }
 
     int CalcAttackDamage(BattleCharacter* receiver)
@@ -56,7 +56,7 @@ public:
     void PoisonDamage()
     {
         int damage = 4;
-        std::cout << m_name << "はどくで" << damage << "ダメージをうけた！" << std::endl;
+        std::cout << m_name << "はどくで " << damage << " ダメージをうけた！" << std::endl;
         SetBattleHp(GetBattleHp() - damage);
     }
 
@@ -73,17 +73,7 @@ public:
         return GetBattleSpeed() >= other->GetBattleSpeed();
     }
 
-    bool IsDie()
-    {
-        if (GetBattleHp() == 0) {
-            DiePrint();
-            return true;
-        }
-        
-        return false;
-    }
-
-    virtual void DiePrint() = 0;
+    bool IsDie() { return GetBattleHp() == 0; }
 
     string GetName() const { return m_name; }
     State& GetState() { return m_state; }

--- a/CUI-RPG/BigBear.hpp
+++ b/CUI-RPG/BigBear.hpp
@@ -1,0 +1,12 @@
+#ifndef BIG_BEAR_H_
+#define BIG_BEAR_H_
+
+#include "Enemy.hpp"
+
+class BigBear : public Enemy
+{
+public:
+    BigBear() : Enemy("おおぐま", 5, 0, 3, 3, 3, 10) {}
+};
+
+#endif // !BIG_BEAR_H_

--- a/CUI-RPG/Brave.hpp
+++ b/CUI-RPG/Brave.hpp
@@ -3,12 +3,26 @@
 
 #include "BattleCharacter.hpp"
 #include <iostream>
+#include <map>
 
 class Brave : public BattleCharacter
 {
 public:
+    using level_t = unsigned short;
+    using exp_t = unsigned short;
+    using map = std::map<level_t, exp_t>;
+
     Brave(string name, ability_t hp, ability_t mp, ability_t attack, ability_t defense, ability_t speed)
-        : BattleCharacter(name, hp, mp, attack, defense, speed) {}
+        : BattleCharacter(name, hp, mp, attack, defense, speed)
+    {
+        m_level = 1;
+        m_exp = 0;
+
+        m_levelToExp.insert(std::make_pair(2, 3));
+        m_levelToExp.insert(std::make_pair(3, 5));
+        m_levelToExp.insert(std::make_pair(4, 8));
+        m_levelToExp.insert(std::make_pair(5, 15));
+    }
     ~Brave() {}
 
     void Action(BattleCharacter* enemy)
@@ -18,6 +32,7 @@ public:
         std::cout << m_name << "はどうする？ > " << std::flush;
         std::cin >> n;
 
+        // TODO: 想定外の値が入力されたときにループさせる例外処理を実装する
         switch (n) {
         case 1:
             Attack(enemy);
@@ -30,10 +45,34 @@ public:
         }
     }
 
-    void DiePrint()
+    bool IsLevelUp() { return m_exp >= m_levelToExp.at(m_level + 1); }
+
+    void OnLevelUp(exp_t exp)
+    {
+        m_exp += exp;
+        level_t beforeLevel = m_level;
+
+        while (m_level != MAX_LEVEL && IsLevelUp()) {
+            ++m_level;
+        }
+
+        int upLevel = m_level - beforeLevel;
+        if (upLevel != 0) {
+            std::cout << m_name << "のレベルが " << upLevel << " あがった！" << std::endl;
+        }
+    }
+
+    void GameOver()
     {
         std::cout << m_name << "はしんでしまった！" << std::endl;
     }
+
+private:
+    const level_t MAX_LEVEL = 99;
+    level_t m_level;
+    exp_t m_exp;
+    map m_levelToExp;
+    // TODO: レベルに対応するステータス表をメンバとして実装する
 };
 
 #endif // !BRAVE_H_

--- a/CUI-RPG/CUI-RPG.vcxproj
+++ b/CUI-RPG/CUI-RPG.vcxproj
@@ -134,6 +134,8 @@
     <ClCompile Include="StateOperation.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Battle.hpp" />
+    <ClInclude Include="BigBear.hpp" />
     <ClInclude Include="Enemy.hpp" />
     <ClInclude Include="State.hpp" />
     <ClInclude Include="BattleCharacter.hpp" />

--- a/CUI-RPG/CUI-RPG.vcxproj.filters
+++ b/CUI-RPG/CUI-RPG.vcxproj.filters
@@ -31,6 +31,21 @@
     <Filter Include="ソース ファイル\state">
       <UniqueIdentifier>{c830584e-34f8-4b7e-aefc-da3300644f94}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ヘッダー ファイル\battle\enemy">
+      <UniqueIdentifier>{e8303881-4968-427a-af07-4c865e795628}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\battle\brave">
+      <UniqueIdentifier>{3877ff94-a809-4880-9427-3f6668a7c35a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\battle\enemy\forest">
+      <UniqueIdentifier>{183ab975-2862-49e6-a90b-3e6bf24875d4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\event">
+      <UniqueIdentifier>{314ee53a-25a9-42cf-8172-600d832db26e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ヘッダー ファイル\event\battle">
+      <UniqueIdentifier>{9c062947-21bc-40f9-93ff-98bfa25f4135}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -59,14 +74,20 @@
     <ClInclude Include="State.hpp">
       <Filter>ヘッダー ファイル\state</Filter>
     </ClInclude>
-    <ClInclude Include="Brave.hpp">
-      <Filter>ヘッダー ファイル\battle</Filter>
-    </ClInclude>
     <ClInclude Include="StateOperation.hpp">
       <Filter>ヘッダー ファイル\state</Filter>
     </ClInclude>
+    <ClInclude Include="Brave.hpp">
+      <Filter>ヘッダー ファイル\battle\brave</Filter>
+    </ClInclude>
     <ClInclude Include="Enemy.hpp">
-      <Filter>ヘッダー ファイル\battle</Filter>
+      <Filter>ヘッダー ファイル\battle\enemy</Filter>
+    </ClInclude>
+    <ClInclude Include="BigBear.hpp">
+      <Filter>ヘッダー ファイル\battle\enemy\forest</Filter>
+    </ClInclude>
+    <ClInclude Include="Battle.hpp">
+      <Filter>ヘッダー ファイル\event\battle</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/CUI-RPG/Enemy.hpp
+++ b/CUI-RPG/Enemy.hpp
@@ -7,8 +7,10 @@
 class Enemy : public BattleCharacter
 {
 public:
-    Enemy(string name, ability_t hp, ability_t mp, ability_t attack, ability_t defense, ability_t speed)
-        : BattleCharacter(name, hp, mp, attack, defense, speed) {}
+    using exp_t = unsigned short;
+
+    Enemy(string name, ability_t hp, ability_t mp, ability_t attack, ability_t defense, ability_t speed, exp_t exp)
+        : BattleCharacter(name, hp, mp, attack, defense, speed), m_exp(exp) {}
     ~Enemy() {}
 
     void Action(BattleCharacter* brave)
@@ -16,10 +18,21 @@ public:
         Attack(brave);
     }
 
+    void Encount()
+    {
+        std::cout << m_name << "があらわれた！" << std::endl;
+    }
+
     void DiePrint()
     {
         std::cout << m_name << "をたおした！" << std::endl;
+        std::cout << m_exp << " のけいけんちをかくとく！" << std::endl;
     }
+
+    exp_t GetExp() { return m_exp; }
+
+private:
+    exp_t m_exp;
 };
 
 #endif // !ENEMY_H_

--- a/CUI-RPG/main.cpp
+++ b/CUI-RPG/main.cpp
@@ -4,31 +4,16 @@
 #include "State.hpp"
 #include "StateOperation.hpp"
 #include "BattleCharacter.hpp"
+#include "BigBear.hpp"
+#include "Battle.hpp"
 #include <iostream>
 #include <vector>
 using namespace std;
 
 int main()
 {
-    BattleCharacter* brave = new Brave("しゅんすけ", 10, 5, 5, 5, 5);
-    BattleCharacter* enemy = new Enemy("てき", 7, 4, 3, 3, 8);
-    StateOperation::SetState(brave, State::POISON);
+    Brave* brave = new Brave("しゅんすけ", 10, 5, 5, 5, 5);
+    Enemy* enemy = new BigBear();
 
-    while (!brave->IsDie() && !enemy->IsDie()) {
-        if (brave->IsFaster(enemy)) {
-            if (!brave->Turn(enemy)) {
-                break;
-            }
-            if (!enemy->Turn(brave)) {
-                break;
-            }
-        } else {
-            if (!enemy->Turn(brave)) {
-                break;
-            }
-            if (!brave->Turn(enemy)) {
-                break;
-            }
-        }
-    }
+    Battle::BattleEvent(brave, enemy);
 }


### PR DESCRIPTION
以下、色々修正の内容
・バトルループとバトル後処理ではBrave, Enemyで新たに定義されたメソッドを使用するため、
　引数をBattleCharacter型ではなくBrave, Enemyに修正
・HPが0になっても行動を続けられるようになってしまっていたため、Turn()の最初でHP判定の早期returnを実装
・↑に伴ってIsDie()の実装を簡略化
・テキスト表示で数字が詰め込まれて見えづらいので前後にスペースを追加