### PR TITLE
乱数生成メソッドを2つに分けた

### DIFF
--- a/CUI-RPG/BigBear.hpp
+++ b/CUI-RPG/BigBear.hpp
@@ -17,7 +17,7 @@ public:
 
     void Action(BattleCharacter& brave)
     {
-        int n = RandomNumGenerator::Generate(1, 4);
+        int n = RandomNumGenerator::FromOneToMax(BASE_ACTION_COUNT + 1);
         if (n <= BASE_ACTION_COUNT) {
             Enemy::Action(m_braveRef, n);
         } else {

--- a/CUI-RPG/Enemy.hpp
+++ b/CUI-RPG/Enemy.hpp
@@ -19,7 +19,7 @@ public:
     virtual void Action(BattleCharacter& brave, int n = 0)
     {
         if (n == 0 || n > BASE_ACTION_COUNT) {
-            n = RandomNumGenerator::Generate(1, 3);
+            n = RandomNumGenerator::FromOneToMax(BASE_ACTION_COUNT);
         }
 
         switch (n) {

--- a/CUI-RPG/PoisonSnake.hpp
+++ b/CUI-RPG/PoisonSnake.hpp
@@ -17,7 +17,7 @@ public:
 
     void Action(BattleCharacter& brave)
     {
-        int n = RandomNumGenerator::Generate(1, 4);
+        int n = RandomNumGenerator::FromOneToMax(BASE_ACTION_COUNT + 1);
         if (n < BASE_ACTION_COUNT) {
             Enemy::Action(m_braveRef, n);
         } else {

--- a/CUI-RPG/RandomNumGenerator.hpp
+++ b/CUI-RPG/RandomNumGenerator.hpp
@@ -6,10 +6,17 @@
 class RandomNumGenerator
 {
 public:
-    static int Generate(int min, int max)
+    static int FromMinToMax(int min, int max)
     {
         std::mt19937 mt{ std::random_device{}() };
         std::uniform_int_distribution<int> dist(min, max);
+        return dist(mt);
+    }
+
+    static int FromOneToMax(int max)
+    {
+        std::mt19937 mt{ std::random_device{}() };
+        std::uniform_int_distribution<int> dist(1, max);
         return dist(mt);
     }
 };


### PR DESCRIPTION
よく考えたら敵のアクションをランダムで決めるのにminが1になるのは当たり前なので、
1から引数までの乱数生成と、引数1から引数2までの乱数生成の2つを実装し、
敵のアクションを決める時にはFromOneToMax()を使うように実装。